### PR TITLE
update ingress to v1 api

### DIFF
--- a/examples/ingress.yaml
+++ b/examples/ingress.yaml
@@ -1,6 +1,6 @@
 ---
 kind: Ingress
-apiVersion: networking.k8s.io/v1beta1
+apiVersion: networking.k8s.io/v1
 metadata:
   name: my-app
 spec:
@@ -9,6 +9,9 @@ spec:
     http:
       paths:
       - path: /
+        pathType: Prefix
         backend:
-          serviceName: myapp
-          servicePort: 80
+          service:
+            name: myapp
+            port:
+              number: 80

--- a/templates/ingress.yaml
+++ b/templates/ingress.yaml
@@ -1,6 +1,6 @@
 ---
 kind: Ingress
-apiVersion: networking.k8s.io/v1beta1
+apiVersion: networking.k8s.io/v1
 metadata:
   name: my-app
 spec:
@@ -9,6 +9,9 @@ spec:
     http:
       paths:
       - path: /
+        pathType: Prefix
         backend:
-          serviceName:
-          servicePort: 
+          service:
+            name:
+            port:
+              number:


### PR DESCRIPTION
For new clusters, the v1beta1 api has been removed so updating the ingress resources to work with v1